### PR TITLE
Fix SelectMenu interactions broken

### DIFF
--- a/Oxide.Ext.Discord/Entities/Interactions/InteractionData.cs
+++ b/Oxide.Ext.Discord/Entities/Interactions/InteractionData.cs
@@ -62,7 +62,7 @@ namespace Oxide.Ext.Discord.Entities.Interactions
         /// For components, the values for the select menu component
         /// </summary>
         [JsonProperty("values")]
-        public List<SelectMenuOption> Values { get; set; }
+        public List<string> Values { get; set; }
         
         /// <summary>
         /// Id the of user or message targeted by a user or message command

--- a/Oxide.Ext.Discord/Entities/Interactions/InteractionDataParsed.cs
+++ b/Oxide.Ext.Discord/Entities/Interactions/InteractionDataParsed.cs
@@ -68,7 +68,7 @@ namespace Oxide.Ext.Discord.Entities.Interactions
         /// <summary>
         /// If a <see cref="SelectMenuComponent"/> triggered this interaction. The values selected from the select menu.
         /// </summary>
-        public readonly List<SelectMenuOption> SelectMenuValues;
+        public readonly List<string> SelectMenuValues;
 
         /// <summary>
         /// Discord User's locale converted to oxide lang locale

--- a/Oxide.Ext.Discord/Entities/Interactions/MessageComponents/SelectMenuComponent.cs
+++ b/Oxide.Ext.Discord/Entities/Interactions/MessageComponents/SelectMenuComponent.cs
@@ -13,7 +13,7 @@ namespace Oxide.Ext.Discord.Entities.Interactions.MessageComponents
         /// The choices in the select
         /// Max 25 options
         /// </summary>
-        [JsonProperty("custom_id")]
+        [JsonProperty("options")]
         public List<SelectMenuOption> Options { get; } = new List<SelectMenuOption>();
         
         /// <summary>


### PR DESCRIPTION
SelectMenu interactions is currently completely broken.

This fix changes the "custom_id" => "options" to match the reference here: [https://discord.com/developers/docs/interactions/message-components#select-menus](https://discord.com/developers/docs/interactions/message-components#select-menus)

It also changes the deserializing of interaction events from select menus.